### PR TITLE
Null replacement option

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -16,6 +16,7 @@ module.exports = function (Model, options) {
     buildOptions: { // Options that will be passed to build process
       notify: true, // Notify model operation hooks on build
     },
+    nullReplacement: null, // if a relational field resolves to null, replace with this value
     mongodbArgs: {}, // MongoDB aggregation arguments
   }, options);
 
@@ -74,8 +75,9 @@ module.exports = function (Model, options) {
             }
             if (relationalFields.length) {
               const relationalWhere = _.pick(filter.where, relationalFields);
+              const nullReplacement = options.nullReplacement;
               buildLookup(aggregation, relationalWhere);
-              aggregation.coalesce(relationalWhere);
+              aggregation.coalesce(relationalWhere, nullReplacement);
               aggregation.match(relationalWhere);
             }
           }

--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -189,7 +189,7 @@ module.exports = class Aggregation {
    * @param {*} coalesce Coalesce value
    * @returns {module.Aggregation}
    */
-  coalesce (fields, coalesce = false) {
+  coalesce (fields, coalesce = null) {
     const addFields = _.mapValues(fields, (value, key) => {
       return {$ifNull: [`$${key}`, coalesce]};
     });

--- a/test/fixtures/simple-app/cities.json
+++ b/test/fixtures/simple-app/cities.json
@@ -12,16 +12,19 @@
   {
     "ref": "city3",
     "name": "Paris",
-    "population": 2200
+    "population": 2200,
+    "isCoastal": false
   },
   {
     "ref": "city4",
     "name": "Buenos Aires",
-    "population": 2890
+    "population": 2890,
+    "isCoastal": true
   },
   {
     "ref": "city5",
     "name": "Vienna",
-    "population": 1868
+    "population": 1868,
+    "isCoastal": false
   }
 ]

--- a/test/fixtures/simple-app/common/models/city.json
+++ b/test/fixtures/simple-app/common/models/city.json
@@ -17,6 +17,9 @@
     },
     "population": {
       "type": "number"
+    },
+    "isCoastal": {
+      "type": "boolean"
     }
   },
   "validations": [],

--- a/test/test.js
+++ b/test/test.js
@@ -548,6 +548,23 @@ describe('Aggregate features', () => {
       });
     });
 
+    it('Should not match nulls when comparing a relation property to false', (done) => {
+      Company.aggregate({
+        include: ['city'],
+        where: {
+          'city.isCoastal': false,
+        },
+      })
+        .then((companies) => {
+          companies.forEach((company) => {
+            const city = company.city();
+            should.exist(city);
+            city.should.have.property('isCoastal').which.eql(false);
+          });
+          done();
+        })
+        .catch((err) => done(err));
+    });
   });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -554,12 +554,41 @@ describe('Aggregate features', () => {
         where: {
           'city.isCoastal': false,
         },
-      })
+      }, {nullReplacement: true})
         .then((companies) => {
           companies.forEach((company) => {
             const city = company.city();
             should.exist(city);
             city.should.have.property('isCoastal').which.eql(false);
+          });
+          done();
+        })
+        .catch((err) => done(err));
+    });
+
+    it('If a relation field is null it should be replaced with nullReplacement option ', (done) => {
+      const nullReplacement = 'wasNotSpecified';
+      Company.aggregate(
+        {
+          include: ['city'],
+          where: {
+            'city.isCoastal': nullReplacement,
+          },
+        },
+        {
+          nullReplacement,
+          buildLater: true,
+        }
+      )
+        .then((data) => {
+          const companies = data[0];
+          should.exist(companies);
+          companies.should.be.Array();
+          should.ok(companies.length > 0);
+          companies.forEach((company) => {
+            const city = company.city;
+            should.exist(city);
+            city.should.have.property('isCoastal').which.eql(nullReplacement);
           });
           done();
         })


### PR DESCRIPTION
Set the default replacement value for the $ifNull operator to 'null' The value can be overwritten by specifying a 'nullReplacement' field int the options object.
Added a new boolean field to the cities, which is not set for some cities. Added tests for checking the behavior of nullReplacement option