### PR TITLE
Handle deep nested relations. Forbid 2 fully identical stages.

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -153,21 +153,19 @@ module.exports = function (Model, options) {
    * @param {Aggregation} aggregate Aggregation to be mutated.
    * @param {Object} where Where filter. Will search for properties with dot notation.
    * @param {Relation} [parentRelation] States that is a nested relation of this one.
+   * @param {Array} ancestorRelationNames names of the current relation's ancestors, including parentRelation.name
+   * 
    */
-  function buildLookup (aggregate, where, parentRelation = null) {
+  function buildLookup (aggregate, where, parentRelation = null, ancestorRelationNames = []) {
     _.each(where, (value, key) => {
       const keys = key.split('.');
       const headKey = keys.shift();
       const relation = (parentRelation ? parentRelation.modelTo : Model).relations[headKey];
       if (!relation) return;
-      const lookupOpts = buildLookupOptsFromRelation(relation, parentRelation);
+      const lookupOpts = buildLookupOptsFromRelation(relation, ancestorRelationNames);
       aggregate.lookup(lookupOpts);
       if (_.includes(['hasOne', 'belongsTo'], relation.type)) {
-        let unwindPath = relation.name;
-        const parentRelationName = _.get(parentRelation, 'name', '');
-        if (parentRelationName.length) {
-          unwindPath = `${parentRelationName}.${unwindPath}`;
-        }
+        const unwindPath = [...ancestorRelationNames, relation.name].join('.');
         aggregate.unwind({
           path: `$${ unwindPath}`,
           preserveNullAndEmptyArrays: true,
@@ -175,8 +173,10 @@ module.exports = function (Model, options) {
       }
       /* istanbul ignore else */
       if (keys.length) {
-        buildLookup(aggregate, {[keys.join('.')]: value}, relation);
+        ancestorRelationNames.push(relation.name);
+        buildLookup(aggregate, {[keys.join('.')]: value}, relation, ancestorRelationNames);
       }
+      ancestorRelationNames = [];
     });
   }
 
@@ -186,14 +186,11 @@ module.exports = function (Model, options) {
    * @param {Relation} parentRelation States that is a nested relation of this one.
    * @returns {{from: String, localField: String, foreignField: String, as: String}}
    */
-  function buildLookupOptsFromRelation (relation, parentRelation) {
+  function buildLookupOptsFromRelation (relation, ancestorRelationNames) {
     let relationName = relation.name;
     let keyFrom = relation.keyFrom === 'id' ? '_id' : relation.keyFrom;
-    const parentRelationName = _.get(parentRelation, 'name', '');
-    if (parentRelationName.length) {
-      relationName = `${parentRelationName}.${relationName}`;
-      keyFrom = `${parentRelationName}.${keyFrom}`;
-    }
+    relationName = [...ancestorRelationNames, relationName].join('.');
+    keyFrom = [...ancestorRelationNames, keyFrom].join('.');
     return {
       from: relation.modelTo.modelName,
       localField: keyFrom,

--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -13,6 +13,18 @@ module.exports = class Aggregation {
   }
 
   /**
+   * Check if an identical stage already exists.
+   * @param {Object} stage One stage.
+   * @returns {Boolean}
+   */
+
+  isDuplicateStage (stage) {
+    return this.pipeline.some((existingStage) => {
+      return _.isEqual(existingStage, stage);
+    });
+  }
+
+  /**
    * Append pipeline stages.
    * @param {Object|Object[]} stages One or several stages.
    * @returns {module.Aggregation}
@@ -23,6 +35,7 @@ module.exports = class Aggregation {
       stages = [stages];
     }
     stages.forEach((stage) => {
+      if (this.isDuplicateStage(stage)) return;
       let op = Object.keys(stage)[0];
       if (!op) {
         throw new Error('Aggregate stage must have a key');

--- a/test/fixtures/simple-app/cities.json
+++ b/test/fixtures/simple-app/cities.json
@@ -2,29 +2,34 @@
   {
     "ref": "city1",
     "name": "London",
-    "population": 8136
+    "population": 8136,
+    "countryId": "GB"
   },
   {
     "ref": "city2",
     "name": "Madrid",
-    "population": 3166
+    "population": 3166,
+    "countryId": "SP"
   },
   {
     "ref": "city3",
     "name": "Paris",
     "population": 2200,
-    "isCoastal": false
+    "isCoastal": false,
+    "countryId": "FR"
   },
   {
     "ref": "city4",
     "name": "Buenos Aires",
     "population": 2890,
-    "isCoastal": true
+    "isCoastal": true,
+    "countryId": "AR"
   },
   {
     "ref": "city5",
     "name": "Vienna",
     "population": 1868,
-    "isCoastal": false
+    "isCoastal": false,
+    "countryId": "AU"
   }
 ]

--- a/test/fixtures/simple-app/common/models/country.json
+++ b/test/fixtures/simple-app/common/models/country.json
@@ -1,7 +1,7 @@
 {
-  "name": "City",
+  "name": "Country",
   "base": "PersistedModel",
-  "idInjection": true,
+  "idInjection": false,
   "options": {
     "validateUpsert": true
   },
@@ -9,7 +9,8 @@
     "Aggregate": true
   },
   "properties": {
-    "ref": {
+    "id": {
+      "id": true,
       "type": "string"
     },
     "name": {
@@ -17,18 +18,9 @@
     },
     "population": {
       "type": "number"
-    },
-    "isCoastal": {
-      "type": "boolean"
     }
   },
   "validations": [],
-  "relations": {
-    "country": {
-      "type": "belongsTo",
-      "model": "Country",
-      "foreignKey": "countryId"
-    }
-  },
+  "relations": {},
   "methods": {}
 }

--- a/test/fixtures/simple-app/countries.json
+++ b/test/fixtures/simple-app/countries.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "GB",
+    "name": "Great Britain",
+    "population": 66000000
+  },
+  {
+    "id": "SP",
+    "name": "Madrid",
+    "population": 46000000
+  },
+  {
+    "id": "FR",
+    "name": "France",
+    "population": 67000000
+  },
+  {
+    "id": "AR",
+    "name": "Argentina",
+    "population": 44000000
+  },
+  {
+    "id": "AU",
+    "name": "Austria",
+    "population": 9000000
+  }
+]

--- a/test/fixtures/simple-app/seeder.js
+++ b/test/fixtures/simple-app/seeder.js
@@ -16,6 +16,7 @@ module.exports = class Seeder {
     const City = this.app.models.City;
     const Company = this.app.models.Company;
     const Person = this.app.models.Person;
+    const Country = this.app.models.Country;
     // Seed cities
     async.mapSeries(require('./cities.json'), (cityData, nextItem) => {
       City.create(cityData, nextItem);
@@ -40,7 +41,13 @@ module.exports = class Seeder {
           if (err) return next(err);
           context.persons = persons;
           context.persons.forEach((person) => context[person.ref] = person);
-          next(null, context);
+          // Seed countries
+          async.mapSeries(require('./countries.json'), (countryData, nextItem) => {
+            Country.create(countryData, nextItem);
+          }, (err) => {
+            if (err) return next(err);
+            next(null, context);
+          });
         });
       });
     });

--- a/test/fixtures/simple-app/server/model-config.json
+++ b/test/fixtures/simple-app/server/model-config.json
@@ -18,5 +18,9 @@
   "City": {
     "dataSource": "db",
     "public": true
+  },
+  "Country": {
+    "dataSource": "db",
+    "public": true
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -591,7 +591,47 @@ describe('Aggregate features', () => {
             city.should.have.property('isCoastal').which.eql(nullReplacement);
           });
           done();
-        })
+        });
+    });
+
+    it('Should aggregate with a 3 level deep relation', (done) => {
+      const countryName = 'Great Britain';
+      Person.aggregate({
+        include: [{
+          relation: 'company',
+          scope: {
+            include: [
+              {
+                relation: 'city',
+                scope: {
+                  include: ['country'],
+                },
+              },
+            ],
+          },
+        }],
+        where: {
+          'company.city.country.name': countryName,
+        },
+      }).then((people) => {
+        should.exist(people);
+        people.should.be.Array();
+        should.ok(people.length > 0, 'people array shoudn\'t be empty');
+        people.forEach((person) => {
+          const company = person.company();
+          company.should.be.Object();
+          company.should.have.property('city');
+  
+          const city = company.city();
+          city.should.be.Object();
+          city.should.have.property('country');
+  
+          const country = city.country();
+          country.should.be.Object();
+          country.should.have.property('name').which.is.eql(countryName);
+        });
+        done();
+      })
         .catch((err) => done(err));
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -634,6 +634,49 @@ describe('Aggregate features', () => {
       })
         .catch((err) => done(err));
     });
+
+    it('Two nested relations with overlapping paths shouldn\'t overwrite each other', (done) => {
+      const countryName = 'Great Britain';
+      const cityName = 'London';
+      Person.aggregate({
+        include: [{
+          relation: 'company',
+          scope: {
+            include: [
+              {
+                relation: 'city',
+                scope: {
+                  include: ['country'],
+                },
+              },
+            ],
+          },
+        }],
+        where: {
+          'company.city.country.name': countryName,
+          'company.city.name': cityName,
+        },
+        limit: 1,
+      }).then((people) => {
+        should.exist(people);
+        people.should.be.Array().and.length(1);
+        const person = people[0];
+        const company = person.company();
+        company.should.be.Object();
+        company.should.have.property('city');
+
+        const city = company.city();
+        city.should.be.Object();
+        city.should.have.property('name').which.is.eql(cityName);
+        city.should.have.property('country');
+
+        const country = city.country();
+        country.should.be.Object();
+        country.should.have.property('name').which.is.eql(countryName);
+        done();
+      })
+        .catch((err) => done(err));
+    });
   });
 
 });


### PR DESCRIPTION
1. Fixed the buildLookup function to carry forward not just the current and the parent relations, but all of the ancestor relation names. Now $unwind and $lookup paths should be built correctly for 3 level and deeper nested relations.
2. Before appending a stage perform a lodash deep equality to see if an identical stage already exists, if so, ignore the stage. Without this fix partially overlapping relation paths would result in multiple identical lookup and unwind stages for the overlapping parts of their paths, and each subsequent stage would overwrite the result of the previous one.

This PR doesn't address any of the remaining 2 issues, these are new.
